### PR TITLE
fix issue leading to slowdown/unbounded memory growth in binary json processing

### DIFF
--- a/rosbridge_library/src/rosbridge_library/protocol.py
+++ b/rosbridge_library/src/rosbridge_library/protocol.py
@@ -121,8 +121,12 @@ class Protocol:
 
         """
         if isinstance(message_string, bytes):
-            message_string = message_string.decode('utf-8')
-        self.buffer = self.buffer + message_string
+            try:
+                message_string = message_string.decode('utf-8')
+            except UnicodeDecodeError:
+                self.log("error", "Received binary message with invalid UTF-8 encoding")
+                return
+            self.buffer = self.buffer + message_string
         msg = None
 
         # take care of having multiple JSON-objects in receiving buffer

--- a/rosbridge_library/src/rosbridge_library/protocol.py
+++ b/rosbridge_library/src/rosbridge_library/protocol.py
@@ -120,7 +120,9 @@ class Protocol:
         message_string -- the wire-level message sent by the client
 
         """
-        self.buffer = self.buffer + str(message_string)
+        if isinstance(message_string, bytes):
+            message_string = message_string.decode('utf-8')
+        self.buffer = self.buffer + message_string
         msg = None
 
         # take care of having multiple JSON-objects in receiving buffer


### PR DESCRIPTION
See upstream PR for more info https://github.com/RobotWebTools/rosbridge_suite/pull/1199

Note - our workflows are forked from a while ago and don't work. I tried updating them with upstreams but they fail too due to linting errors. Will have an internal conversation about aligning this repo with upstream - for now the tests will fail but they're old/not ours and this doesn't matter here